### PR TITLE
Fix WarningSign lineicon not picking height and width

### DIFF
--- a/assets/icons/svgs/svgLineIcons/WarningSign.svg
+++ b/assets/icons/svgs/svgLineIcons/WarningSign.svg
@@ -1,10 +1,4 @@
-<svg
-    id="Layer_1"
-    data-name="Layer 1"
-    xmlns="http://www.w3.org/2000/svg"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    viewBox="0 0 24 24"
->
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <defs>
         <style>
             .stroke {
@@ -13,15 +7,9 @@
         </style>
     </defs>
 
-    <circle class="stroke" stroke-linecap="round" stroke-linejoin="round" cx="12.04" cy="15.72" r=".5" />
+    <circle class="stroke" fill="none" stroke-linecap="round" stroke-linejoin="round" cx="12.04" cy="15.72" r=".5" />
 
-    <path stroke-width="2" class="stroke" stroke-linecap="round" stroke-linejoin="round" d="m12,10v3" />
-    <path
-        stroke-width="2"
-        fill="none"
-        class="stroke"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        d="m12,4l8.66,15H3.34L12,4Z"
-    />
+    <path stroke-width="2" fill="none" class="stroke" stroke-linecap="round" stroke-linejoin="round" d="m12,10v3" />
+    <path stroke-width="2" fill="none" class="stroke" stroke-linecap="round" stroke-linejoin="round"
+        d="m12,4l8.66,15H3.34L12,4Z" />
 </svg>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@setu/crucible-icons",
-    "version": "1.0.16",
+    "version": "1.0.17",
     "description": "Crucible Icons package",
     "license": "MIT",
     "main": "./dist/cjs/index.js",

--- a/src/icons/reactLineIcons/WarningSign.tsx
+++ b/src/icons/reactLineIcons/WarningSign.tsx
@@ -10,16 +10,19 @@ export const WarningSign = React.forwardRef<SVGSVGElement, LineIconProps>(
         return (
             <SVGLineIconWrapper {...props}>
                 <svg
+                    width={width}
+                    height={height}
+                    ref={forwardedRef}
                     id="Layer_1"
                     data-name="Layer 1"
                     xmlns="http://www.w3.org/2000/svg"
-                    xmlnsXlink="http://www.w3.org/1999/xlink"
                     viewBox="0 0 24 24"
                 >
                     <defs></defs>
 
                     <circle
                         className="stroke"
+                        fill="none"
                         strokeLinecap="round"
                         strokeLinejoin="round"
                         cx="12.04"
@@ -29,6 +32,7 @@ export const WarningSign = React.forwardRef<SVGSVGElement, LineIconProps>(
 
                     <path
                         strokeWidth="2"
+                        fill="none"
                         className="stroke"
                         strokeLinecap="round"
                         strokeLinejoin="round"


### PR DESCRIPTION
WarningSign asset had the svg format like so : 

`<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewbox="0 0 24 24">`

This wasn't getting picked up by the build scripts to attach `height` and `width` props eventually leading to not populating within the package/storybook

This has been fixed and checked. Closing #35 